### PR TITLE
changes to bulk_file_upload_method

### DIFF
--- a/lib/gupshup.rb
+++ b/lib/gupshup.rb
@@ -55,7 +55,7 @@ module Gupshup
         return false, "HTTP Error : #{res}"
       end
     end
-
+pu
     def send_message(opts)
       msg = opts[:msg]
       number = opts[:send_to]
@@ -94,7 +94,7 @@ module Gupshup
       msg_params[:xlsFile] = file
       resp = HTTPClient.post(@api_url,msg_params.merge(@api_params).merge(opts))
       file.close
-      puts resp.body
+      p resp.body
     end
     
     def group_post(opts)

--- a/lib/gupshup.rb
+++ b/lib/gupshup.rb
@@ -94,7 +94,7 @@ module Gupshup
       msg_params[:xlsFile] = file
       resp = HTTPClient.post(@api_url,msg_params.merge(@api_params).merge(opts))
       file.close
-      puts resp.body.content
+      puts resp.body
     end
     
     def group_post(opts)

--- a/lib/gupshup.rb
+++ b/lib/gupshup.rb
@@ -55,7 +55,7 @@ module Gupshup
         return false, "HTTP Error : #{res}"
       end
     end
-pu
+
     def send_message(opts)
       msg = opts[:msg]
       number = opts[:send_to]


### PR DESCRIPTION
replaced puts with p
returning rest.body and not rest.body.content

Response body from api is a pipe  |  separated string.